### PR TITLE
Fix deprecation error with PyTorch 2.8.0

### DIFF
--- a/example.py
+++ b/example.py
@@ -130,7 +130,7 @@ def main(args):
 
     # load the model
     _, model = get_model(cfg, device)
-    ckpt = torch.load(ckpt_path, map_location=torch.device('cpu'))
+    ckpt = torch.load(ckpt_path, map_location=torch.device('cpu'), weights_only=False)
     model.load_state_dict(ckpt['model'])
     model.eval()
 


### PR DESCRIPTION
Minor thing but with the latest PyTorch release I couldn't test the pretrained models without explicitly setting `weights_only=False`.

Believe this came into play as of 2.6.0: https://github.com/pytorch/pytorch/releases/tag/v2.6.0