### PR TITLE
Add Python package definition

### DIFF
--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -29,4 +29,4 @@ jobs:
         run: pip install pytest
 
       - name: Run tests
-        run: pytest
+        run: pytest tests

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -1,0 +1,32 @@
+name: pytest
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.11", "3.12", "3.x"]
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+
+      - name: Install package
+        run: pip install .
+
+      - name: Install test runner
+        run: pip install pytest
+
+      - name: Run tests
+        run: pytest

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ temp
 *.pyth
 todel
 .vscode
+build
+*.egg-info

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,30 @@
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "synchformer"
+version = "0.1.0"
+description = "Efficient synchronization from sparse cues"
+readme = "README.md"
+requires-python = ">=3.11"
+dependencies = [
+    "einops>=0.8.1",
+    "ftfy>=6.1.1",
+    "matplotlib>=3.10.6",
+    "numpy>=2.3.3",
+    "omegaconf>=2.3.0",
+    "regex>=2022.7.9",
+    "requests>=2.32.5",
+    "scikit-learn>=1.7.2",
+    "scipy>=1.16.2",
+    "torch>=2.8.0",
+    "torchaudio>=2.8.0",
+    "torchvision>=0.23.0",
+    "tqdm>=4.67.1",
+]
+
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["*"]
+exclude = ["_repo_assets"]

--- a/tests/test_train_utils.py
+++ b/tests/test_train_utils.py
@@ -1,0 +1,29 @@
+import pytest
+import torch
+
+from scripts.train_utils import prepare_inputs
+
+
+@pytest.mark.parametrize("get_targets", [True, False])
+def test_prepare_inputs(get_targets):
+
+    video_shape = (2, 3, 224, 224)
+    audio_shape = (2, 16000)
+    batch = {
+        "video": torch.randn(*video_shape),
+        "audio": torch.randn(*audio_shape),
+        "targets": {
+            "offset_target": torch.tensor([0, 1]),
+        },
+    }
+
+    device = "cpu"
+    phase = "train"
+    audio, video, targets = prepare_inputs(batch, device, phase, get_targets)
+
+    assert audio.shape == audio_shape
+    assert video.shape == video_shape
+
+    if get_targets:
+        assert targets is not None
+        assert targets["offset_target"].shape == (2,)

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -1,0 +1,9 @@
+import torch
+
+from dataset.transforms import make_class_grid
+
+
+def test_make_class_grid():
+    grid = make_class_grid(-1.0, 1.0, 5)
+    expected_grid = torch.tensor([-1.0, -0.5, 0.0, 0.5, 1.0])
+    assert torch.allclose(grid, expected_grid)


### PR DESCRIPTION
### What?
1. Add a basic pyproject.toml next to the conda environment, to make the Synchformer code `pip install`:able
2. Add a GitHub Actions workflow to test that `pip install` works
3. Add two lightweight unit tests (mostly to make sure `import` works after install)

Tested to work [here](https://github.com/carlthome/Synchformer/actions/runs/18740852342)

### Why?

After this change, it will be possible to run

```sh
pip install ./Synchformer
python -c "import Synchformer.data"
```
and
```sh
python -m Synchformer.example --help    
usage: example.py [-h] --exp_name EXP_NAME --vid_path VID_PATH [--offset_sec OFFSET_SEC] [--v_start_i_sec V_START_I_SEC] [--device DEVICE]

options:
  -h, --help            show this help message and exit
  --exp_name EXP_NAME   In a format: xx-xx-xxTxx-xx-xx
  --vid_path VID_PATH   A path to .mp4 video
  --offset_sec OFFSET_SEC
  --v_start_i_sec V_START_I_SEC
  --device DEVICE
```
which is a nice convenience for testing this out. I've made sure to not change any existing code to make this work (such that things behave the same as before).